### PR TITLE
Allow libcjson-dev packages to be installed instead of cloning into lib/

### DIFF
--- a/config
+++ b/config
@@ -16,8 +16,7 @@ deps="$ngx_addon_dir/inc/ngx_http_waf_module_check.h \
     $ngx_addon_dir/inc/ngx_http_waf_module_under_attack.h \
     $ngx_addon_dir/inc/ngx_http_waf_module_captcha.h \
     $ngx_addon_dir/inc/ngx_http_waf_module_verify_bot.h \
-    $ngx_addon_dir/inc/ngx_http_waf_module_modsecurity.h \
-    $ngx_addon_dir/lib/cjson/cJSON.h"
+    $ngx_addon_dir/inc/ngx_http_waf_module_modsecurity.h"
 
 srcs="$ngx_addon_dir/src/ngx_http_waf_module_core.c \
     $ngx_addon_dir/src/ngx_http_waf_module_var.c \
@@ -33,8 +32,7 @@ srcs="$ngx_addon_dir/src/ngx_http_waf_module_core.c \
     $ngx_addon_dir/src/ngx_http_waf_module_captcha.c \
     $ngx_addon_dir/src/ngx_http_waf_module_verify_bot.c \
     $ngx_addon_dir/src/ngx_http_waf_module_modsecurity.c \
-    $ngx_addon_dir/src/ngx_http_waf_module_util.c \
-    $ngx_addon_dir/lib/cjson/cJSON.c"
+    $ngx_addon_dir/src/ngx_http_waf_module_util.c"
 
 
 ngx_http_waf_module_libs=""


### PR DESCRIPTION
Remove hardcoded $ngx_addon_dir/lib/cjson/cJSON.h, it prevents building with installed OS packages (other modules are trying to depend on it). And ngx_waf builds fine without this when libcjson is cloned into the lib/ dir anyway

Running in production on https://deb.myguard.nl/nginx-modules (where this module is included by the way)